### PR TITLE
Added mechanisms to handle unsaved changes and menu item to create new collection in Metadata Editor

### DIFF
--- a/code/+om/+ui/UICollection.m
+++ b/code/+om/+ui/UICollection.m
@@ -661,7 +661,7 @@ classdef UICollection < openminds.Collection
                     if ~isempty(options)
                         % Question/todo: Should we make a protected
                         % categorical with this extra option?
-                        rowValues = cell(numRows, 1);
+                        rowValues = strings(numRows, 1);
                         for jRow = 1:numRows
                             thisValue =  instanceTable{jRow,i};
                             if iscell(thisValue); thisValue = [thisValue{:}]; end
@@ -683,16 +683,16 @@ classdef UICollection < openminds.Collection
                                     thisValue = options(1);
                                 end
                             end
+                            rowValues(jRow) = thisValue;
                         end
 
                         % Build categorical after all potential options are
                         % collected
                         uniqueOptions = unique(options);
                         uniqueOptions(uniqueOptions == "") = [];
-                        for jRow = 1:numRows
-                            rowValues{jRow} = categorical(thisValue, uniqueOptions, 'Protected', true);
-                        end
-
+                        rowValues = categorical(rowValues, uniqueOptions, 'Protected', true);
+                        rowValues = num2cell(rowValues);
+                        
                         instanceTable.(thisColumnName) = cat(1, rowValues{:});
                     else
                         if isa(firstValue, 'openminds.abstract.Schema')

--- a/code/apps/+om/+command/saveMetadataCollection.m
+++ b/code/apps/+om/+command/saveMetadataCollection.m
@@ -51,5 +51,5 @@ function saveMetadataCollection(metadataCollection, filepath)
     MetadataCollection = metadataCollection;
     save(filepath, 'MetadataCollection');
     
-    fprintf('Metadata collection exported to %s\n', filepath);
+    fprintf('Metadata collection saved to %s\n', filepath);
 end

--- a/code/apps/+om/@MetadataEditor/MetadataEditor.m
+++ b/code/apps/+om/@MetadataEditor/MetadataEditor.m
@@ -621,6 +621,7 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
                 propValue = string(propValue);
             end
             obj.MetadataCollection.modifyInstance(instanceID, propName, propValue);
+            obj.HasUnsavedChanges = true;
         end
 
         function onTypeSelectionChanged(obj, ~, evt)
@@ -954,6 +955,14 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
         function menuCallback_SaveCollection(obj)
             % Save collection to its current location
             filepath = obj.getMetadataCollectionFilepath();
+            if isempty(char(filepath))
+                obj.menuCallback_SaveCollectionAs()
+                return
+            end
+            [~, dlcgCleanup] = obj.uiprogressdlg( ...
+                sprintf('Saving changes to %s...', filepath), ...
+                'Title', 'Saving Collection', ...
+                'Indeterminate', 'on'); %#ok<ASGLU>
             om.command.saveMetadataCollection(obj.MetadataCollection, filepath);
             obj.HasUnsavedChanges = false;  % Clear unsaved changes flag
 
@@ -963,6 +972,8 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
         end
 
         function menuCallback_SaveCollectionAs(obj)
+            [~, dlcgCleanup] = obj.uiprogressdlg('Saving changes...', ...
+                'Indeterminate', 'on'); %#ok<ASGLU>
             collection = obj.MetadataCollection;
             filePath = om.command.saveMetadataCollectionAs(collection);
 


### PR DESCRIPTION
This pull request introduces a mechanism for tracking and handling unsaved changes in the `MetadataEditor` UI. The update ensures users are prompted before losing unsaved work, adds a "New collection" menu option, and refines how collections are loaded and saved. Additionally, there are minor improvements to the collection export message and some refactoring for clarity and maintainability.

**Unsaved Changes Management:**

* Added a `HasUnsavedChanges` property to `MetadataEditor` and logic to update this flag whenever the metadata collection or its instances are modified. [[1]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R55) [[2]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R624) [[3]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R744) [[4]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R755)
* Implemented `checkUnsavedChanges` method to prompt users to save, discard, or cancel when unsaved changes exist before closing, opening, or creating a new collection. This logic is integrated into relevant menu callbacks and the exit handler. [[1]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R269-R302) [[2]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L165-R172) [[3]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R932-R982) [[4]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L916-R1025) [[5]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L970-R1073)
* Ensured the unsaved changes flag is reset when loading, saving, or creating collections. [[1]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R79) [[2]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R565) [[3]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R582-R584) [[4]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R932-R982) [[5]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L970-R1073)

**Menu and UI Improvements:**

* Added "New collection" to the main menu and ensured it checks for unsaved changes before proceeding.

**Refactoring and Code Quality:**

* Refactored collection loading logic into a new helper method `loadCollectionIntoEditor` to reduce duplication and improve maintainability.
* Improved error handling and user feedback when opening collections. [[1]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L916-R1025) [[2]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L970-R1073)

**Minor Improvements:**

* Updated export message in `saveMetadataCollection` to clarify that the collection is "saved" rather than "exported".

**Collection Table Handling:**

* Fixed conversion of table columns to categoricals in `UICollection.m`.