### PR TITLE
Improve table context menus for Metadata Tables in `MetadataEditor`

### DIFF
--- a/code/apps/+om/+internal/+control/+abstract/MetaTableViewer.m
+++ b/code/apps/+om/+internal/+control/+abstract/MetaTableViewer.m
@@ -20,6 +20,9 @@ classdef (Abstract) MetaTableViewer < handle & matlab.mixin.SetGet
 % - Handle cell edit
 % - id column is not editable
 
+% Some context menu items could be table generic, like delete row, hide
+% column etc.
+
     % Public properties
     properties (SetAccess = public) % Todo: protected
         MetaTable                           % Table or nansen.metadata.MetaTable
@@ -43,6 +46,7 @@ classdef (Abstract) MetaTableViewer < handle & matlab.mixin.SetGet
         MouseDoubleClickedFcn = []           % Alias for MouseClickedCallback (for NANSEN compatibility)
         KeyPressCallback = []                % Callback for key presses
         TableContextMenu
+        ColumnHeaderContextMenu % Not implemented yet
     end
     
     % UI State
@@ -140,9 +144,14 @@ classdef (Abstract) MetaTableViewer < handle & matlab.mixin.SetGet
             obj.updateTableDisplay();
         end
         
-        function delete(~)
+        function delete(obj)
             %delete Cleanup when object is destroyed
-            % Subclasses should override to clean up UI components
+            if ~isempty(obj.TableContextMenu) && isvalid(obj.TableContextMenu)
+                delete(obj.TableContextMenu);
+            end
+            if ~isempty(obj.ColumnHeaderContextMenu) && isvalid(obj.ColumnHeaderContextMenu)
+                delete(obj.ColumnHeaderContextMenu);
+            end
         end
     end
     
@@ -162,6 +171,16 @@ classdef (Abstract) MetaTableViewer < handle & matlab.mixin.SetGet
             
             % Update variable attributes
             %obj.updateMetaTableVariableAttributes();
+        end
+    
+        function set.TableContextMenu(obj, value)
+            obj.TableContextMenu = value;
+            obj.postSetTableContextMenu()
+        end
+
+        function set.ColumnHeaderContextMenu(obj, value)
+            obj.ColumnHeaderContextMenu = value;
+            obj.postSetColumnHeaderContextMenu()
         end
     end
     
@@ -357,5 +376,10 @@ classdef (Abstract) MetaTableViewer < handle & matlab.mixin.SetGet
                 obj.CellSelectionCallback(obj, evtData);
             end
         end
+    end
+
+    methods (Abstract, Access = protected) % Property post set methods
+        postSetTableContextMenu(obj)
+        postSetColumnHeaderContextMenu(obj)
     end
 end

--- a/code/apps/+om/+internal/+control/UIMetaTable.m
+++ b/code/apps/+om/+internal/+control/UIMetaTable.m
@@ -276,6 +276,8 @@ classdef UIMetaTable < om.internal.control.abstract.MetaTableViewer
 
             if isOutsideTable
                 % Do nothing - all items hidden by default or keep current state
+                [obj.PrivateTableContextMenu.Children.Visible] = deal('off');
+
 
             % Conditionally show/hide context menu items based on whether user
             % right clicks in the table or in the table column header

--- a/code/apps/+om/@MetadataEditor/MetadataEditor.m
+++ b/code/apps/+om/@MetadataEditor/MetadataEditor.m
@@ -308,6 +308,13 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
             varName = matlab.lang.makeValidName( schemaInstance.DisplayString );
             assignin('base', varName, schemaInstance)
         end
+
+        function exportCollectionToWorkspace(obj)
+            % Export the metadata collection to the workspace
+            varName = 'metadataCollection';
+            assignin('base', varName, obj.MetadataCollection);
+            fprintf('Metadata collection assigned to workspace variable: %s\n', varName);
+        end
     end
 
     methods (Access = private) % App initialization and update methods
@@ -391,11 +398,15 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
             mItem = uimenu(m, 'Text', 'Save collection', 'Accelerator', 's', 'Separator', 'on');
             mItem.Callback = @(s,e) obj.menuCallback_SaveCollection;
 
-            mItem = uimenu(m, 'Text', 'Save collection as...', 'Accelerator', 'w');
+            mItem = uimenu(m, 'Text', 'Save collection as...');
             mItem.Callback = @(s,e) obj.menuCallback_SaveCollectionAs;
 
             mItem = uimenu(m, 'Text', 'Export collection...', 'Accelerator', 'e');
             mItem.Callback = @(s,e) obj.menuCallback_ExportCollection;
+
+            mItem = uimenu(m, 'Text', 'Assign collection in workspace', 'Accelerator', 'w');
+            mItem.Callback = @(s,e) obj.exportCollectionToWorkspace;
+
 
             mItem = uimenu(m, 'Text', 'Select project type', 'Separator', 'on');
             L = recursiveDir( fullfile(om.internal.rootpath, 'config', 'template_projects'), 'Type','folder');
@@ -497,6 +508,7 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
             [menuInstance, graphicsMenu] = om.TableContextMenu(obj.Figure);
             obj.UIMetaTableViewer.TableContextMenu = graphicsMenu;
             menuInstance.DeleteItemFcn = @obj.onDeleteMetadataInstanceClicked;
+            menuInstance.ExportToWorkspaceFcn = @obj.onExportToWorkspaceClicked;
         end
 
         function plotOpenMindsLogo(obj)
@@ -780,6 +792,11 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
             obj.CurrentTableInstanceIds = ids;
             % app.MetaTable.removeEntries(selectedEntries)
             % app.UiMetaTableViewer.refreshTable(app.MetaTable)
+        end
+
+        function onExportToWorkspaceClicked(obj, ~, ~)
+            % Export selected instance(s) to workspace
+            obj.exportToWorkspace()
         end
 
         function onMouseDoubleClickedInTable(obj, ~, evt)

--- a/code/apps/+om/@MetadataEditor/MetadataEditor.m
+++ b/code/apps/+om/@MetadataEditor/MetadataEditor.m
@@ -505,10 +505,17 @@ classdef MetadataEditor < handle & om.app.mixin.HasDialogs
         end
 
         function initializeTableContextMenu(obj)
+            % Create table context menu (for table body)
             [menuInstance, graphicsMenu] = om.TableContextMenu(obj.Figure);
-            obj.UIMetaTableViewer.TableContextMenu = graphicsMenu;
             menuInstance.DeleteItemFcn = @obj.onDeleteMetadataInstanceClicked;
             menuInstance.ExportToWorkspaceFcn = @obj.onExportToWorkspaceClicked;
+            obj.UIMetaTableViewer.TableContextMenu = graphicsMenu;
+
+            % Create column header context menu
+            columnHeaderMenu = uicontextmenu(obj.Figure);
+            uimenu(columnHeaderMenu, 'Text', 'Hide Column', ...
+                'MenuSelectedFcn', @(s,e) obj.hideColumn());
+            obj.UIMetaTableViewer.ColumnHeaderContextMenu = columnHeaderMenu;
         end
 
         function plotOpenMindsLogo(obj)

--- a/code/apps/+om/TableContextMenu.m
+++ b/code/apps/+om/TableContextMenu.m
@@ -2,6 +2,7 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
 
     properties
         DeleteItemFcn
+        ExportToWorkspaceFcn
     end
 
     properties (Access = private)
@@ -9,6 +10,7 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
         UIContextMenu
 
         UIMenuItemDeleteItem
+        UIMenuItemExportToWorkspace
     end
 
     methods
@@ -40,6 +42,11 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
             obj.DeleteItemFcn = value;
             obj.postSetDeleteItemFcn()
         end
+
+        function set.ExportToWorkspaceFcn(obj, value)
+            obj.ExportToWorkspaceFcn = value;
+            obj.postSetExportToWorkspaceFcn()
+        end
     end
 
     methods (Access = private)
@@ -47,10 +54,14 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
 
             obj.UIMenuItemDeleteItem = uimenu(obj.UIContextMenu, ...
                 "Text", "Delete instance");
+            
+            obj.UIMenuItemExportToWorkspace = uimenu(obj.UIContextMenu, ...
+                "Text", "Export to workspace");
         end
 
         function assignMenuItemCallbacks(obj)
             obj.UIMenuItemDeleteItem.Callback = obj.DeleteItemFcn;
+            obj.UIMenuItemExportToWorkspace.Callback = obj.ExportToWorkspaceFcn;
         end
     end
 
@@ -58,6 +69,10 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
     methods (Access = private)
         function postSetDeleteItemFcn(obj)
             obj.UIMenuItemDeleteItem.Callback = obj.DeleteItemFcn;
+        end
+
+        function postSetExportToWorkspaceFcn(obj)
+            obj.UIMenuItemExportToWorkspace.Callback = obj.ExportToWorkspaceFcn;
         end
     end
 end

--- a/code/apps/+om/TableContextMenu.m
+++ b/code/apps/+om/TableContextMenu.m
@@ -51,12 +51,11 @@ classdef TableContextMenu < handle & matlab.mixin.SetGet
 
     methods (Access = private)
         function createMenuItems(obj)
-
-            obj.UIMenuItemDeleteItem = uimenu(obj.UIContextMenu, ...
-                "Text", "Delete instance");
-            
             obj.UIMenuItemExportToWorkspace = uimenu(obj.UIContextMenu, ...
                 "Text", "Export to workspace");
+
+            obj.UIMenuItemDeleteItem = uimenu(obj.UIContextMenu, ...
+                "Text", "Delete instance", "Separator", "on");
         end
 
         function assignMenuItemCallbacks(obj)


### PR DESCRIPTION
- Fixed bug when removing instances from `UICollection`.
- Refactored (Improved) internal handling of table and column header context menus
- Added context menu item for exporting metadata instances to workspace from table

**Metadata Collection Management**

* Added an overridden `remove` method to `UICollection` that removes a metadata instance from both the collection and its associated graph node, and notifies listeners of collection changes. This centralizes removal logic and ensures consistent event handling.
* Updated deprecated removal methods (`removeDeprecated`, `removeInstance`) to use the new `remove` method, eliminating duplicate graph node removal logic and improving maintainability. [[1]](diffhunk://#diff-f7ec6729e879f1600888eb72aff2dd94027f09b9cd44ec1c5bb7759b179fd595L139-R188) [[2]](diffhunk://#diff-f7ec6729e879f1600888eb72aff2dd94027f09b9cd44ec1c5bb7759b179fd595L149-R208) [[3]](diffhunk://#diff-f7ec6729e879f1600888eb72aff2dd94027f09b9cd44ec1c5bb7759b179fd595L177-L184)
* Added a private `configureNodesIfNeeded` method to ensure `Nodes` are properly initialized as a dictionary when required. [[1]](diffhunk://#diff-f7ec6729e879f1600888eb72aff2dd94027f09b9cd44ec1c5bb7759b179fd595R59-R60) [[2]](diffhunk://#diff-f7ec6729e879f1600888eb72aff2dd94027f09b9cd44ec1c5bb7759b179fd595R442-R451)

**UI Context Menu Refactoring**

* Refactored context menu logic in `UIMetaTable` and `MetaTableViewer` to support separate table and column header context menus, and introduced a unified private context menu that dynamically shows/hides items based on click location. This improves user experience and code clarity. [[1]](diffhunk://#diff-deb7088309ac00771746449122ded3753c3a94911fd2e9101c917e4373de1c4dR49) [[2]](diffhunk://#diff-deb7088309ac00771746449122ded3753c3a94911fd2e9101c917e4373de1c4dL143-R154) [[3]](diffhunk://#diff-deb7088309ac00771746449122ded3753c3a94911fd2e9101c917e4373de1c4dR175-R184) [[4]](diffhunk://#diff-deb7088309ac00771746449122ded3753c3a94911fd2e9101c917e4373de1c4dR380-R384) [[5]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713L15-R20) [[6]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713L145-R142) [[7]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713L177-L179) [[8]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713L219-L238) [[9]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713L295-R295) [[10]](diffhunk://#diff-edb5d5e772c529ff74c0935ebd29c02baddccc43ced702a369ce064ca7b6c713R314-L337) [[11]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R508-R518)

**Workspace Export Feature**

* Added a new menu item and method to allow users to assign the entire metadata collection to a variable in the MATLAB workspace, facilitating further analysis and debugging. [[1]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075R311-R317) [[2]](diffhunk://#diff-cd0b99433a6f82df9390fe34fa3143c6106ffaed5c9b3a03c7e8da84ffeb4075L394-R410)
